### PR TITLE
remove specific versions from Pipfile

### DIFF
--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -3,23 +3,23 @@ url = "https://pypi.python.org/simple"
 verify_ssl = true
 
 [dev-packages]
-bumpversion = "==0.5.3"
-wheel = "==0.30.0"
-watchdog = "==0.8.3"
-flake8 = "==3.5.0"
-tox = "==2.9.1"
-coverage = "==4.5.1"
+bumpversion = "*"
+wheel = "*"
+watchdog = "*"
+flake8 = "*"
+tox = "*"
+coverage = "*"
 {%- if cookiecutter.use_pytest == 'y' %}
-pytest = "==3.4.2"
-pytest-runner = "==2.11.1"
+pytest = "*"
+pytest-runner = "*"
 {%- endif %}
 {%- if 'no' not in cookiecutter.command_line_interface|lower %}
-PyInstaller = "==3.3.1"
+PyInstaller = "*"
 {%- endif %}
-Sphinx = "==1.7.1"
-twine = "==1.10.0"
+Sphinx = "*"
+twine = "*"
 
 [packages]
 {%- if cookiecutter.command_line_interface|lower == 'click' %}
-click = "==6.7"
+click = "*"
 {%- endif %}


### PR DESCRIPTION
Locking the dependencies doesn't make sense, especially not in development mode and not as a general rule of thumb.

This is what the users will use the Pipfile.lock file lock for, locking a working version of their repository.