### PR TITLE
Use pipenv development dependencies for running tox

### DIFF
--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -14,16 +14,10 @@ deps = flake8
 commands = flake8 {{ cookiecutter.project_slug }}
 
 [testenv]
-setenv =
-    PYTHONPATH = {toxinidir}
 {% if cookiecutter.use_pytest == 'y' -%}
-deps =
-    -r{toxinidir}/requirements_dev.txt
-; If you want to make tox run the tests with the same versions, create a
-; requirements.txt with the pinned versions and uncomment the following line:
-;     -r{toxinidir}/requirements.txt
+deps = pipenv
 commands =
-    pip install -U pip
+    pipenv install --dev
     py.test --basetemp={envtmpdir}
 {% else %}
 commands = python setup.py test


### PR DESCRIPTION
As recommended here https://pipenv.readthedocs.io/en/latest/advanced/#tox-automation-project we use the pipenv dev dependencies to run the tox environments.

This pull request also solves this issue https://github.com/elgertam/cookiecutter-pipenv/issues/5 as we are not requiring the `dev-requirements.txt` file anymore.