### PR TITLE
Travis-CI fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 # Config file for automatic testing at travis-ci.org
 
 language: python
+dist: xenial
 python:
-  - 3.6
-  - 3.5
-  - 3.4
-  - 2.7
-  - pypy
+  - "3.7"
+  - "3.6"
+  - "3.5"
+  - "2.7"
+  - "pypy"
 # pypy3.5 is currently not supported as mentioned here https://github.com/pypa/pipenv/issues/3313
 #  - pypy3.5
 
@@ -15,15 +16,3 @@ install: pip install -U tox-travis
 
 # command to run tests, e.g. python setup.py test
 script: tox
-
-# deploy new versions to PyPI
-deploy:
-  provider: pypi
-  distributions: sdist bdist_wheel
-  user: audreyr
-  password:
-    secure: PLEASE_REPLACE_ME
-  on:
-    tags: true
-    repo: audreyr/python_boilerplate
-    python: 2.7

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Features
 
 * Testing setup with ``unittest`` and ``python setup.py test`` or ``py.test``
 * Travis-CI_: Ready for Travis Continuous Integration testing
-* Tox_ testing: Setup to easily test for Python 2.7, 3.4, 3.5, 3.6
+* Tox_ testing: Setup to easily test for Python 2.7, 3.5, 3.6, 3.7
 * Sphinx_ docs: Documentation ready for generation with, for example, ReadTheDocs_
 * Bumpversion_: Pre-configured version bumping with a single command
 * Auto-release to PyPI_ when you push a new tag to master (optional)

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py27, py34, py35, p36, pypy, docs
+envlist = py27, py35, py36, py37, pypy, docs
 skipsdist = true
 
 [travis]
 python =
+    3.7: py37
     3.6: py36
     3.5: py35
-    3.4: py34
     2.7: py27
 
 [testenv:docs]

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -1,11 +1,12 @@
 # Config file for automatic testing at travis-ci.org
 
 language: python
+dist: xenial
 python:
-  - 3.6
-  - 3.5
-  - 3.4
-  - 2.7
+  - "3.7"
+  - "3.6"
+  - "3.5"
+  - "2.7"
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis
@@ -27,5 +28,5 @@ deploy:
   on:
     tags: true
     repo: {{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
-    python: 3.6
+    python: 3.7
 {%- endif %}


### PR DESCRIPTION
- Updating project .travis.yml to drop support for 3.4.x and add it for
3.7.x
- Updating slugged project to drop support for 3.4.x and add it for
3.7.x
- Updated readme to list Python versions now supported
- Updated tox.ini to reflect the changed support