### PR TITLE
Travis update

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,9 +16,10 @@ PyYAML = ">=4.2b1"
 requests = ">=2.20.0"
 Jinja2 = ">=2.10.1"
 urllib3 = ">=1.24.2"
+pytest-runner = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.7"
 
 [pipenv]
 allow_prereleases = true

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-e1839a8 = {path = ".",editable = true}
+e1839a8 = {path = ".", editable = true}
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "759e771a2aee5e945176f1d9f733cd9ee1fac88ead964d47a2e794fc7dc69fe3"
+            "sha256": "337fab593fae44b0cd876711d5ebbe43ffd87e888914dbc7d5177063cafad6f2"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_version": "3.7"
         },
         "sources": [
             {
@@ -199,6 +199,14 @@
             ],
             "index": "pypi",
             "version": "==0.3.0"
+        },
+        "pytest-runner": {
+            "hashes": [
+                "sha256:00ad6cd754ce55b01b868a6d00b77161e4d2006b3918bde882376a0a884d0df4",
+                "sha256:e946c7dbdc8c0c2ffa44e7b45450f68e7f08cb133983134fa63a1d1486c2b36b"
+            ],
+            "index": "pypi",
+            "version": "==4.4"
         },
         "python-dateutil": {
             "hashes": [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, pypy, docs
+envlist = py{27,35,36,37}, pypy, docs
 skipsdist = true
 
 [travis]

--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -20,6 +20,7 @@ Sphinx = "*"
 twine = "*"
 
 [packages]
+"deadbee" = {path = ".", editable = true}
 {%- if cookiecutter.command_line_interface|lower == 'click' %}
 click = "*"
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py27, py34, py35, py36, flake8
+envlist = py27, py35, py36, py37, flake8
 
 [travis]
 python =
+    3.7: py37
     3.6: py36
     3.5: py35
-    3.4: py34
     2.7: py27
 
 [testenv:flake8]


### PR DESCRIPTION
Updated tox, Pipfile and template in order to support Python 3.7, remove support for Python 3.4 and ensure all tests pass.